### PR TITLE
Rearrange old unittests.py; Use nosetests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ install: build-stamp
 
 check:
 	python piuparts.py unittest
-	python unittests.py
+	nosetests -c nosetests.cfg
 
 clean:
 	rm -f build-stamp

--- a/nosetests.cfg
+++ b/nosetests.cfg
@@ -1,0 +1,14 @@
+[nosetests]
+# create test coverage report
+with-coverage=1
+with-coverage=1
+cover-html=1
+cover-html-dir=build/html
+cover-package=piupartslib,piuparts
+#cover-inclusive=1
+
+# run doctests
+with-doctest=1
+
+# catch all tests
+# all-modules=1

--- a/tests/test_dependencyparser.py
+++ b/tests/test_dependencyparser.py
@@ -1,0 +1,33 @@
+import unittest
+import piupartslib.dependencyparser
+
+
+class DependencyParserTests(unittest.TestCase):
+
+    """Tests for module dependencyparser."""
+
+    def parse(self, str):
+        parser = piupartslib.dependencyparser.DependencyParser(str)
+        deps = parser.get_dependencies()
+        names = []
+        for dep in deps:
+            names.append([])
+            for simpledep in dep:
+                names[-1].append(simpledep.name)
+        return deps, names
+
+    def testEmpty(self):
+        deps, names = self.parse("")
+        self.failUnlessEqual(deps, [])
+
+    def testSingle(self):
+        deps, names = self.parse("foo")
+        self.failUnlessEqual(names, [["foo"]])
+
+    def testTwo(self):
+        deps, names = self.parse("foo, bar")
+        self.failUnlessEqual(names, [["foo"], ["bar"]])
+
+    def testAlternatives(self):
+        deps, names = self.parse("foo, bar | foobar")
+        self.failUnlessEqual(names, [["foo"], ["bar", "foobar"]])

--- a/tests/unittests.py
+++ b/tests/unittests.py
@@ -6,38 +6,6 @@ import unittest
 
 
 import piupartslib.packagesdb
-import piupartslib.dependencyparser
-
-
-class DependencyParserTests(unittest.TestCase):
-
-    """Tests for module dependencyparser."""
-
-    def parse(self, str):
-        parser = piupartslib.dependencyparser.DependencyParser(str)
-        deps = parser.get_dependencies()
-        names = []
-        for dep in deps:
-            names.append([])
-            for simpledep in dep:
-                names[-1].append(simpledep.name)
-        return deps, names
-
-    def testEmpty(self):
-        deps, names = self.parse("")
-        self.failUnlessEqual(deps, [])
-
-    def testSingle(self):
-        deps, names = self.parse("foo")
-        self.failUnlessEqual(names, [["foo"]])
-
-    def testTwo(self):
-        deps, names = self.parse("foo, bar")
-        self.failUnlessEqual(names, [["foo"], ["bar"]])
-
-    def testAlternatives(self):
-        deps, names = self.parse("foo, bar | foobar")
-        self.failUnlessEqual(names, [["foo"], ["bar", "foobar"]])
 
 
 class FakeLogDB(piupartslib.packagesdb.LogDB):


### PR DESCRIPTION
Hello Holger, 

in order to get the tests running (and to get a base for adding more tests) i moved the unittests.py to a sub directory "tests/" in which nosetests searches for tests. I also added a configuration for nosetests that writes a test coverage report (the coverage report is saved in build/html). 
- Move unittests.py to tests/ subdirectory
- Split out dependencyparser test to an extra file
- Add configuration for nosetests
- Use nosetests in Makefile target "check"
