### PR TITLE
Enable unittests during package build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ install: build-stamp
 
 check:
 	python piuparts.py unittest
-	nosetests -c nosetests.cfg
+	nosetests --verbose
 
 clean:
 	rm -f build-stamp

--- a/debian/changelog
+++ b/debian/changelog
@@ -10,6 +10,9 @@ piuparts (0.57) UNRELEASED; urgency=low
     - Split out dependencyparser test to an extra file,
     - Add configuration for nosetests,
     - Use nosetests in Makefile target "check".
+  * Re-enable unittests during package build
+    - Don't create coverage report during pkg build.
+    - Added needed Build-Depends
 
  -- Holger Levsen <holger@debian.org>  Fri, 10 Jan 2014 01:00:43 +0100
 

--- a/debian/control
+++ b/debian/control
@@ -8,6 +8,11 @@ Standards-Version: 3.9.5
 Build-Depends:
  debhelper (>= 9.20120909~),
  python (>= 2.7),
+ python-debian,
+ python-apt,
+ python-nose,
+ python-debianbts,
+ python-yaml
 Build-Depends-Indep:
  asciidoc,
  git,

--- a/debian/rules
+++ b/debian/rules
@@ -10,9 +10,6 @@
 override_dh_auto_build:
 	$(MAKE) prefix=/usr build build-doc
 
-override_dh_auto_test:
-	echo "unittests are disabled as they haven't been run at build time since years and thus are broken..."
-
 override_dh_auto_install:
 	$(MAKE) DESTDIR=$(CURDIR)/debian/tmp prefix=/usr etcdir=/etc install install-doc install-conf
 


### PR DESCRIPTION
Hi Holger,

i try to address the points you brought up in the last pull-request [1]: 
- Added needed Build-Depends
- Re-enable unittests in debian/rules
- Don't create coverage files during package build

This enables the unittests now for every package build and use nosetests for it (but don't create coverage reports). I added python-nose (and a bunch more) to the Build-Depends. Is this ok? You wrote about "something like Build-recommends" so did you think it would be to much to run the tests in every build?

Best wishes,
Matthias 
[1] https://github.com/h01ger/piuparts/pull/1 
