### PR TITLE
ignore /root/.rnd as it will created every time we call OpenSSL

### DIFF
--- a/piuparts.py
+++ b/piuparts.py
@@ -244,6 +244,7 @@ class Settings:
             "/var/cache/ldconfig/aux-cache",
             "/var/crash/",
             "/var/games/",
+            "/root/.rnd",
             # package management
             "/etc/apt/apt.conf.d/01autoremove-kernels",
             "/etc/apt/secring.gpg",


### PR DESCRIPTION
maintainer scripts often call OpenSSL to create a random string or hash something.